### PR TITLE
Make the CoC a normal page

### DIFF
--- a/public/code_of_conduct.html
+++ b/public/code_of_conduct.html
@@ -11,12 +11,10 @@
   <link rel="stylesheet" type="text/css" href="stylesheets/github-light.css" media="screen">
 </head>
 <body>
-<section class="page-header">
-  <h1 class="project-name"><a href="index.html">&amp;:conf</a></h1>
-  <h2 class="project-tagline">code retreat and unconference</h2>
-</section>
 
 <section class="main-content">
+  <h1><a href="index.html">&amp;:conf</a></h1>
+
   <h2>
     <a id="code-of-conduct" class="anchor" href="#code-of-conduct" aria-hidden="true"><span
       class="octicon octicon-link"></span></a>Code of Conduct</h2>


### PR DESCRIPTION
Minor housekeeping. Just adding a "normal page" style so we don't have to make everyone download Trees Jumbotron™ on every page.

![screen shot 2015-05-31 at 4 02 39 pm](https://cloud.githubusercontent.com/assets/187987/7904421/96900f1e-07ae-11e5-908b-5f501d31b323.png)

Going to merge to keep things moving, but if you have feedback, happy to open another PR to address it.

cc @lilliealbert @stellacotton 
